### PR TITLE
Fix api queue

### DIFF
--- a/packages/main/src/handlers/fdc3/1.2/open.ts
+++ b/packages/main/src/handlers/fdc3/1.2/open.ts
@@ -56,17 +56,19 @@ export const open = async (message: RuntimeMessage) => {
       newView = await runtime.createView(start_url, {
         directoryData: directoryEntry,
       });
-      console.log('@@@@@@@@@@@@@ open - created new window', newView);
+      console.log('@@@@@@@@@@@@@ open - created new window', newView.id);
     } else {
       //else get target workspace
       const sourceView = runtime.getView(message.source);
       const work =
         runtime.getWorkspace(message.source) ||
         (sourceView && sourceView.parent);
-      newView =
-        work &&
-        (await work.createView(start_url, { directoryData: directoryEntry }));
-      console.log('@@@@@@@@@@@@@ open - created new tab', newView);
+      if (work) {
+        newView = await work.createView(start_url, {
+          directoryData: directoryEntry,
+        });
+        console.log('@@@@@@@@@@@@@ open - created new tab', newView.id);
+      }
     }
 
     //set provided context

--- a/packages/main/src/handlers/fdc3/1.2/raiseIntent.ts
+++ b/packages/main/src/handlers/fdc3/1.2/raiseIntent.ts
@@ -265,13 +265,18 @@ export const raiseIntent = async (message: RuntimeMessage) => {
           .details as DirectoryAppLaunchDetailsWeb;
         const start_url = directoryDetails.url;
         const pending = true;
-
-        const view = await getRuntime().createView(start_url, {
+        const runtime = getRuntime();
+        const view = await runtime.createView(start_url, {
           directoryData: directoryData,
         });
 
         //set pending intent for the view..
         if (view && pending) {
+          console.log(
+            '!!!! raiseIntent - setPending intent',
+            intent,
+            message.data.context,
+          );
           view.setPendingIntent(
             intent,
             (message.data && message.data.context) || undefined,

--- a/packages/main/src/handlers/runtime/tabs.ts
+++ b/packages/main/src/handlers/runtime/tabs.ts
@@ -114,11 +114,12 @@ export const dropTab = async (message: RuntimeMessage) => {
 
 export const closeTab = async (message: RuntimeMessage) => {
   const runtime = getRuntime();
-  //bring selected browserview to front
   const workspace = runtime.getWorkspace(message.source);
+  //remove tab from its workspace
   if (workspace) {
     workspace.closeTab(message.data.tabId);
   }
+
   return;
 };
 

--- a/packages/main/src/runtime.ts
+++ b/packages/main/src/runtime.ts
@@ -399,15 +399,34 @@ export class Runtime {
     return result;
   }
 
-  async createView(url?: string, config?: ViewConfig): Promise<View | void> {
+  /* createView(url?: string, config?: ViewConfig): Promise<View | void> {
+    return new Promise((resolve) => {
     new Workspace({
       onInit: (workspace: Workspace) => {
-        return new Promise(() => {
+        return new Promise((resolve) => {
           workspace.createView(url, config).then((view) => {
-            return view;
+            resolve(view);
           });
         });
       },
+    });
+  });
+  }*/
+
+  createView(url?: string, config?: ViewConfig): Promise<View> {
+    return new Promise((resolve, reject) => {
+      new Workspace({
+        onInit: (workspace: Workspace) => {
+          return new Promise(() => {
+            try {
+              const view = workspace.createView(url, config);
+              resolve(view);
+            } catch (err) {
+              reject(err);
+            }
+          });
+        },
+      });
     });
   }
 

--- a/packages/main/src/workspace.ts
+++ b/packages/main/src/workspace.ts
@@ -652,15 +652,15 @@ export class Workspace {
     });
   }
 
-  createView(url?: string, config?: ViewConfig): Promise<View> {
-    return new Promise(() => {
+  /*createView(url?: string, config?: ViewConfig): Promise<View> {
+    return new Promise((resolve) => {
       const conf = config || {};
       conf.workspace = this;
-      conf.onReady = (view) => {
-        return new Promise((resolve, reject) => {
+      conf.onReady = async (view) => {
+      
           console.log('view ready');
           this.views.push(view);
-
+          
           if (this.window) {
             console.log('adding tab', view.id, view.getTitle());
 
@@ -674,21 +674,11 @@ export class Workspace {
             // this.window.addBrowserView(view.content);
             console.log('createView - join view to channel', url, this.channel);
             if (this.channel) {
-              this.joinViewToChannel(this.channel, view).then(
-                () => {
-                  resolve(view);
-                },
-                (err: Error) => {
-                  reject(err);
-                },
-              );
-            } else {
-              resolve(view);
-            }
-          } else {
-            reject('No window exists');
-          }
-        });
+              this.joinViewToChannel(this.channel, view);
+            } 
+          return;
+
+        }
       };
 
       const view = new View(url, conf, this, conf.version);
@@ -696,8 +686,54 @@ export class Workspace {
       //add to view collection
       if (this.window) {
         this.window.addBrowserView(view.content);
-      }
+      } 
+      resolve(view);
+      
     });
+  }*/
+
+  createView(url?: string, config?: ViewConfig): View {
+    const conf = config || {};
+    conf.workspace = this;
+    conf.onReady = (view) => {
+      console.log('view ready');
+      this.views.push(view);
+      return new Promise((resolve, reject) => {
+        if (this.window) {
+          console.log('adding tab', view.id, view.getTitle());
+
+          this.window.webContents.send(RUNTIME_TOPICS.ADD_TAB, {
+            viewId: view.id,
+            title: view.getTitle(),
+          });
+
+          this.setSelectedTab(view.id);
+
+          // this.window.addBrowserView(view.content);
+          console.log('createView - join view to channel', url, this.channel);
+          if (this.channel) {
+            this.joinViewToChannel(this.channel, view).then(
+              () => {
+                resolve();
+              },
+              (err: Error) => {
+                reject(err);
+              },
+            );
+          }
+        } else {
+          reject('No window exists');
+        }
+      });
+    };
+
+    const view = new View(url, conf, this, conf.version);
+
+    //add to view collection
+    if (this.window) {
+      this.window.addBrowserView(view.content);
+    }
+    return view;
   }
 
   getViews(): Array<View> {


### PR DESCRIPTION
@robmoffat  - I incorporated your previous changes 'in spirit' - since they dropped some other necessary features in send message.  Queued fdc3 calls should now call send message and return promises.  Async signatures for open, channels/broadcast, and intents are now correct as far as I can tell.  Unfortunately, conformance tests are still having issues though.   I want to get these changes locked first before any deeper dive into that.