### PR TITLE
Secure launching of external origins

### DIFF
--- a/packages/main/src/directory/directory.ts
+++ b/packages/main/src/directory/directory.ts
@@ -20,6 +20,7 @@ export type DirectoryAppSailManifest = {
   searchable: boolean;
   forceNewWindow: boolean;
   framesApi: boolean;
+  allowedOrigins: Array<string>;
 };
 
 /**

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow } from 'electron';
-import './security-restrictions';
 import { Runtime } from './runtime';
 
 let runtime: Runtime | null = null;
@@ -108,7 +107,6 @@ app.on('activate', async () => {
   }
   runtime = new Runtime();
   runtime.startup();
-
   await createWindow();
   return;
 });

--- a/packages/main/src/runtime.ts
+++ b/packages/main/src/runtime.ts
@@ -16,6 +16,7 @@ import { fdc3_2_0_AppDirectoryLoader } from './directory/fdc3-20-loader';
 import { register as registerFDC3_2_0_Handlers } from './handlers/fdc3/2.0/index';
 import { register as registerFDC3_1_2_Handlers } from './handlers/fdc3/1.2/index';
 import { ChannelData } from './types/Channel';
+import { setRuntimeSecurityRestrictions } from './security-restrictions';
 import {
   SessionState,
   ViewState,
@@ -72,6 +73,7 @@ export class Runtime {
       contexts.set(chan.id, []);
     });
     await this.initDirectory();
+    setRuntimeSecurityRestrictions(this);
     return;
   }
 

--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -1,5 +1,7 @@
 import { app, shell } from 'electron';
 import { URL } from 'url';
+import { Runtime } from './runtime';
+import { getSailManifest } from './directory/directory';
 
 /**
  * List of origins that you allow open INSIDE the application and permissions for each of them.
@@ -20,6 +22,7 @@ const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
     | 'pointerLock'
     | 'fullscreen'
     | 'openExternal'
+    | 'window-placement'
     | 'unknown'
   >
 >(
@@ -28,6 +31,7 @@ const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
     : [],
 );
 
+const ALLOWED_EXTERNAL_ORIGINS = new Set<string>([]);
 /**
  * List of origins that you allow open IN BROWSER.
  * Navigation to origins below is possible only if the link opens in a new window
@@ -38,104 +42,114 @@ const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
  *   href="https://github.com/"
  * >
  */
-const ALLOWED_EXTERNAL_ORIGINS = new Set<string>([]);
 
-app.on('web-contents-created', (_, contents) => {
-  /**
-   * Block navigation to origins not on the allowlist.
-   *
-   * Navigation is a common attack vector. If an attacker can convince the app to navigate away
-   * from its current page, they can possibly force the app to open web sites on the Internet.
-   *
-   * @see https://www.electronjs.org/docs/latest/tutorial/security#13-disable-or-limit-navigation
-   */
-  contents.on('will-navigate', (event, url) => {
-    const { origin } = new URL(url);
-    if (ALLOWED_ORIGINS_AND_PERMISSIONS.has(origin)) {
-      return;
-    }
+export const setRuntimeSecurityRestrictions = (runtime: Runtime) => {
+  if (runtime.directory) {
+    runtime.directory.apps.forEach((app) => {
+      const manifest = getSailManifest(app);
+      manifest.allowedOrigins?.forEach((origin) => {
+        ALLOWED_ORIGINS_AND_PERMISSIONS.set(origin, new Set());
+      });
+    });
+  }
 
-    // Prevent navigation
-    event.preventDefault();
-
-    if (import.meta.env.DEV) {
-      console.warn('Blocked navigating to an unallowed origin:', origin);
-    }
-  });
-
-  /**
-   * Block requested unallowed permissions.
-   * By default, Electron will automatically approve all permission requests.
-   *
-   * @see https://www.electronjs.org/docs/latest/tutorial/security#5-handle-session-permission-requests-from-remote-content
-   */
-  contents.session.setPermissionRequestHandler(
-    (webContents, permission, callback) => {
-      const { origin } = new URL(webContents.getURL());
-
-      const permissionGranted =
-        !!ALLOWED_ORIGINS_AND_PERMISSIONS.get(origin)?.has(permission);
-      callback(permissionGranted);
-
-      if (!permissionGranted && import.meta.env.DEV) {
-        console.warn(
-          `${origin} requested permission for '${permission}', but was blocked.`,
-        );
-      }
-    },
-  );
-
-  /**
-   * Hyperlinks to allowed sites open in the default browser.
-   *
-   * The creation of new `webContents` is a common attack vector. Attackers attempt to convince the app to create new windows,
-   * frames, or other renderer processes with more privileges than they had before; or with pages opened that they couldn't open before.
-   * You should deny any unexpected window creation.
-   *
-   * @see https://www.electronjs.org/docs/latest/tutorial/security#14-disable-or-limit-creation-of-new-windows
-   * @see https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-openexternal-with-untrusted-content
-   */
-  contents.setWindowOpenHandler(({ url }) => {
-    const { origin } = new URL(url);
-
-    // '@ts-expect-error' Type checking is performed in runtime
-    if (ALLOWED_EXTERNAL_ORIGINS.has(origin)) {
-      // Open default browser
-      shell.openExternal(url).catch(console.error);
-    } else if (import.meta.env.DEV) {
-      console.warn('Blocked the opening of an unallowed origin:', origin);
-    }
-
-    // Prevent creating new window in application
-    return { action: 'deny' };
-  });
-
-  /**
-   * Verify webview options before creation
-   *
-   * Strip away preload scripts, disable Node.js integration, and ensure origins are on the allowlist.
-   *
-   * @see https://www.electronjs.org/docs/latest/tutorial/security#12-verify-webview-options-before-creation
-   */
-  contents.on('will-attach-webview', (event, webPreferences, params) => {
-    const { origin } = new URL(params.src);
-    if (!ALLOWED_ORIGINS_AND_PERMISSIONS.has(origin)) {
-      if (import.meta.env.DEV) {
-        console.warn(
-          `A webview tried to attach ${params.src}, but was blocked.`,
-        );
+  app.on('web-contents-created', (_, contents) => {
+    /**
+     * Block navigation to origins not on the allowlist.
+     *
+     * Navigation is a common attack vector. If an attacker can convince the app to navigate away
+     * from its current page, they can possibly force the app to open web sites on the Internet.
+     *
+     * @see https://www.electronjs.org/docs/latest/tutorial/security#13-disable-or-limit-navigation
+     */
+    contents.on('will-navigate', (event, url) => {
+      const { origin } = new URL(url);
+      if (ALLOWED_ORIGINS_AND_PERMISSIONS.has(origin)) {
+        return;
       }
 
+      // Prevent navigation
       event.preventDefault();
-      return;
-    }
 
-    // Strip away preload scripts if unused or verify their location is legitimate
-    delete webPreferences.preload;
-    // @ts-expect-error `preloadURL` exists - see https://www.electronjs.org/docs/latest/api/web-contents#event-will-attach-webview
-    delete webPreferences.preloadURL;
+      if (import.meta.env.DEV) {
+        console.warn('Blocked navigating to an unallowed origin:', origin);
+      }
+    });
 
-    // Disable Node.js integration
-    webPreferences.nodeIntegration = false;
+    /**
+     * Block requested unallowed permissions.
+     * By default, Electron will automatically approve all permission requests.
+     *
+     * @see https://www.electronjs.org/docs/latest/tutorial/security#5-handle-session-permission-requests-from-remote-content
+     */
+    contents.session.setPermissionRequestHandler(
+      (webContents, permission, callback) => {
+        const { origin } = new URL(webContents.getURL());
+
+        const permissionGranted =
+          !!ALLOWED_ORIGINS_AND_PERMISSIONS.get(origin)?.has(permission);
+        callback(permissionGranted);
+
+        if (!permissionGranted && import.meta.env.DEV) {
+          console.warn(
+            `${origin} requested permission for '${permission}', but was blocked.`,
+          );
+        }
+      },
+    );
+
+    /**
+     * Hyperlinks to allowed sites open in the default browser.
+     *
+     * The creation of new `webContents` is a common attack vector. Attackers attempt to convince the app to create new windows,
+     * frames, or other renderer processes with more privileges than they had before; or with pages opened that they couldn't open before.
+     * You should deny any unexpected window creation.
+     *
+     * @see https://www.electronjs.org/docs/latest/tutorial/security#14-disable-or-limit-creation-of-new-windows
+     * @see https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-openexternal-with-untrusted-content
+     */
+    contents.setWindowOpenHandler(({ url }) => {
+      const { origin } = new URL(url);
+
+      // '@ts-expect-error' Type checking is performed in runtime
+      if (ALLOWED_EXTERNAL_ORIGINS.has(origin)) {
+        // Open default browser
+        shell.openExternal(url).catch(console.error);
+      } else if (import.meta.env.DEV) {
+        console.warn('Blocked the opening of an unallowed origin:', origin);
+      }
+
+      // Prevent creating new window in application
+      return { action: 'deny' };
+    });
+
+    /**
+     * Verify webview options before creation
+     *
+     * Strip away preload scripts, disable Node.js integration, and ensure origins are on the allowlist.
+     *
+     * @see https://www.electronjs.org/docs/latest/tutorial/security#12-verify-webview-options-before-creation
+     */
+    contents.on('will-attach-webview', (event, webPreferences, params) => {
+      const { origin } = new URL(params.src);
+      if (!ALLOWED_ORIGINS_AND_PERMISSIONS.has(origin)) {
+        if (import.meta.env.DEV) {
+          console.warn(
+            `A webview tried to attach ${params.src}, but was blocked.`,
+          );
+        }
+
+        event.preventDefault();
+        return;
+      }
+
+      // Strip away preload scripts if unused or verify their location is legitimate
+      delete webPreferences.preload;
+      // @ts-expect-error `preloadURL` exists - see https://www.electronjs.org/docs/latest/api/web-contents#event-will-attach-webview
+      delete webPreferences.preloadURL;
+
+      // Disable Node.js integration
+      webPreferences.nodeIntegration = false;
+    });
   });
-});
+};


### PR DESCRIPTION
By default, Sail restricts apps from opening windows in new origins.  Apps that used OAuth redirects or launched other apps or URLs would get blocked and fail silently.  There was a mechanism in place for adding trusted origins - but this was within the *security-restrictions.ts* file (in main)- which meant the list essentially had to be hard coded in.  

This PR adds a new property to the SailManifest  for apps in the App Directory that can list any number of trusted origins for the app (note : this assumes the directory can be trusted).  The App is then allowed to launch these origins and/or redirect to them.  

Also, if  a non-trusted origin is now launched by an app, it will now open in the default browser (instead of just failing).

