### PR TITLE
Returns the Intent result

### DIFF
--- a/packages/main/src/handlers/fdc3/2.0/raiseIntent.ts
+++ b/packages/main/src/handlers/fdc3/2.0/raiseIntent.ts
@@ -1,4 +1,4 @@
-import { ResolveError, AppIdentifier, ResultError } from '@finos/fdc3';
+import { ResolveError, AppIdentifier } from '@finos/fdc3';
 import { getRuntime } from '/@/index';
 import { View } from '/@/view';
 import {
@@ -198,7 +198,7 @@ export const getIntentResult = async (message: FDC3Message) => {
   const messageData: IntentResultData = message.data as IntentResultData;
   const result = runtime.getIntentResult(messageData.resultId);
   console.log('**************** gotintent result', result);
-  return ResultError;
+  return result;
 };
 
 export const setIntentResult = async (message: FDC3Message) => {

--- a/packages/preload/src/fdc3-2.0/api.ts
+++ b/packages/preload/src/fdc3-2.0/api.ts
@@ -536,10 +536,9 @@ export const createAPI = (): DesktopAgent => {
                       FDC3_2_0_TOPICS.GET_INTENT_RESULT,
                       getResultMsg,
                     ).then(
-                      (intentResult) => {
+                      (intentResult: IntentResult) => {
                         console.log('got intent result', intentResult);
-                        const iResult: IntentResult = { type: 'empty' };
-                        resolve(iResult);
+                        resolve(intentResult);
                       },
                       (err) => {
                         reject(err);


### PR DESCRIPTION
## Changes
This PR adds some fixes to support GetResult from Intent of FDC3 v2.

- I removed some mocked code (See [1st commit](https://github.com/finos/FDC3-Sail/pull/137/commits/85f85cdde0d865e750d439bd059642573e9041e2))
- In some case, there was a race condition problem. The getIntentResult was called before the call to "setIntentResult". Consequently, the intent result was undefined. So, I made a change to return a promise that will only be resolved by setIntentResult. (See [2nd commit](https://github.com/finos/FDC3-Sail/pull/137/commits/63e769d99f3eab2e1ed623c52da82666cd0431a6))

## Demo

### Before the fix

**Before the fix the intent Result was empty**

<img width="771" alt="Screenshot 2023-05-04 at 14 10 29" src="https://user-images.githubusercontent.com/66668470/236199956-0e5d375e-6e8e-4be8-bb72-c41966648e04.png">

**And in the logs of Sail the intent result was returned before the call to setIntentResult**

![Screenshot 2023-05-04 at 14 10 48-2](https://user-images.githubusercontent.com/66668470/236200324-f890b546-879e-4cd6-8048-0963074cbf87.png)

### With the fix

**With the fix the Intent result is correctly returned**

<img width="1248" alt="Screenshot 2023-05-04 at 13 44 08" src="https://user-images.githubusercontent.com/66668470/236195554-f0ade349-3edf-4584-9398-32041319475e.png">

**And you can see that a promise is returned for getIntentResult**
![Screenshot 2023-05-04 at 13 44 30-2](https://user-images.githubusercontent.com/66668470/236196298-1145231d-1738-4e83-a485-8a978230d7e7.png)
