### PR TITLE
Fix workspace store persistence rehydration

### DIFF
--- a/packages/sail-web/src/__tests__/stores/workspace-store.test.ts
+++ b/packages/sail-web/src/__tests__/stores/workspace-store.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, beforeEach, vi } from "vite-plus/test"
+import { createWorkspaceStore, type Workspace } from "../../stores/workspace-store"
+
+type PersistedWorkspaceFixture = {
+  state: {
+    workspaces: [
+      string,
+      {
+        layout: {
+          tabs: [
+            string,
+            {
+              panels: unknown[]
+            },
+          ][]
+        }
+      },
+    ][]
+  }
+}
+
+const createWorkspace = (): Workspace => ({
+  uuid: "workspace-1",
+  name: "Demo Workspace",
+  timeLastSaved: 123,
+  layout: {
+    activeTabId: "tab-1",
+    dockviewLayout: {
+      grid: {
+        root: {
+          type: "leaf",
+          data: {
+            views: ["panel-1"],
+            activeView: "panel-1",
+          },
+        },
+      },
+      panels: {
+        "panel-1": {
+          id: "panel-1",
+          title: "TraderX",
+        },
+      },
+    },
+    tabs: new Map([
+      [
+        "tab-1",
+        {
+          tabId: "tab-1",
+          name: "Main",
+          panels: new Map([
+            [
+              "panel-1",
+              {
+                panelId: "panel-1",
+                appId: "traderx-web",
+                title: "TraderX",
+                url: "http://localhost:8080/trade",
+                icon: null,
+              },
+            ],
+          ]),
+        },
+      ],
+    ]),
+  },
+})
+
+describe("workspace-store persistence", () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>()
+    Object.assign(localStorage, {
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage.set(key, value)
+      }),
+      removeItem: vi.fn((key: string) => {
+        storage.delete(key)
+      }),
+      clear: vi.fn(() => {
+        storage.clear()
+      }),
+    })
+  })
+
+  it("serializes nested workspace maps as JSON arrays", () => {
+    const workspace = createWorkspace()
+    const store = createWorkspaceStore({
+      initialWorkspaces: [workspace],
+      activeWorkspaceId: workspace.uuid,
+      storageName: "workspace-store-test",
+    })
+
+    store.getState().setDockviewLayout(workspace.uuid, workspace.layout.dockviewLayout)
+
+    const raw = localStorage.getItem("workspace-store-test")
+    expect(raw).toBeTruthy()
+    const persisted = JSON.parse(raw!) as PersistedWorkspaceFixture
+    expect(Array.isArray(persisted.state.workspaces)).toBe(true)
+    expect(persisted.state.workspaces[0][0]).toBe("workspace-1")
+    expect(Array.isArray(persisted.state.workspaces[0][1].layout.tabs)).toBe(true)
+    expect(Array.isArray(persisted.state.workspaces[0][1].layout.tabs[0][1].panels)).toBe(true)
+  })
+
+  it("rehydrates persisted workspace arrays back into maps", () => {
+    const workspace = createWorkspace()
+    localStorage.setItem(
+      "workspace-store-test",
+      JSON.stringify({
+        state: {
+          workspaces: [
+            [
+              workspace.uuid,
+              {
+                ...workspace,
+                layout: {
+                  ...workspace.layout,
+                  tabs: [
+                    [
+                      "tab-1",
+                      {
+                        tabId: "tab-1",
+                        name: "Main",
+                        panels: [
+                          [
+                            "panel-1",
+                            {
+                              panelId: "panel-1",
+                              appId: "traderx-web",
+                              title: "TraderX",
+                              url: "http://localhost:8080/trade",
+                              icon: null,
+                            },
+                          ],
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              },
+            ],
+          ],
+          activeWorkspaceId: workspace.uuid,
+        },
+        version: 0,
+      })
+    )
+
+    const store = createWorkspaceStore({ storageName: "workspace-store-test" })
+    const rehydrated = store.getState().getWorkspace(workspace.uuid)
+
+    expect(store.getState().workspaces).toBeInstanceOf(Map)
+    expect(rehydrated?.layout.tabs).toBeInstanceOf(Map)
+    expect(rehydrated?.layout.tabs.get("tab-1")?.panels).toBeInstanceOf(Map)
+    expect(store.getState().getPanel(workspace.uuid, "tab-1", "panel-1")?.appId).toBe("traderx-web")
+  })
+
+  it("uses configured initial workspaces when there is no persisted state", () => {
+    const workspace = createWorkspace()
+    const store = createWorkspaceStore({
+      initialWorkspaces: [workspace],
+      activeWorkspaceId: workspace.uuid,
+      storageName: "workspace-store-test",
+    })
+
+    expect(store.getState().activeWorkspaceId).toBe(workspace.uuid)
+    expect(store.getState().getWorkspace(workspace.uuid)?.name).toBe("Demo Workspace")
+  })
+})

--- a/packages/sail-web/src/stores/workspace-store.ts
+++ b/packages/sail-web/src/stores/workspace-store.ts
@@ -73,6 +73,12 @@ interface WorkspaceActions {
 
 export interface WorkspaceStore extends WorkspaceState, WorkspaceActions {}
 
+export interface WorkspaceStoreOptions {
+  initialWorkspaces?: Workspace[]
+  activeWorkspaceId?: string
+  storageName?: string
+}
+
 // Helper function to generate UUIDs
 const generateUUID = (): string => {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
@@ -108,84 +114,107 @@ const createDefaultWorkspace = (): Workspace => {
   }
 }
 
+type PersistedPanel = Panel
+
+interface PersistedTab extends Omit<Tab, "panels"> {
+  panels: [string, PersistedPanel][] | Record<string, PersistedPanel>
+}
+
+interface PersistedWorkspace extends Omit<Workspace, "layout"> {
+  layout: Omit<Grid, "tabs"> & {
+    tabs: [string, PersistedTab][] | Record<string, PersistedTab>
+  }
+}
+
+interface PersistedWorkspaceState {
+  state: Omit<WorkspaceState, "workspaces"> & {
+    workspaces: [string, PersistedWorkspace][] | Record<string, PersistedWorkspace>
+  }
+  version?: number
+}
+
+const entriesFromPersisted = <T>(
+  value: [string, T][] | Record<string, T> | Map<string, T> | undefined
+): [string, T][] => {
+  if (!value) return []
+  if (value instanceof Map) return Array.from(value.entries())
+  if (Array.isArray(value)) return value
+  return Object.entries(value)
+}
+
+const deserializeWorkspaces = (
+  workspaces: PersistedWorkspaceState["state"]["workspaces"]
+): Map<string, Workspace> => {
+  return new Map(
+    entriesFromPersisted(workspaces).map(([workspaceId, workspace]) => [
+      workspaceId,
+      {
+        ...workspace,
+        layout: {
+          ...workspace.layout,
+          tabs: new Map(
+            entriesFromPersisted(workspace.layout.tabs).map(([tabId, tab]) => [
+              tabId,
+              {
+                ...tab,
+                panels: new Map(entriesFromPersisted(tab.panels)),
+              },
+            ])
+          ),
+        },
+      },
+    ])
+  )
+}
+
+const serializeWorkspaces = (
+  workspaces: Map<string, Workspace>
+): [string, PersistedWorkspace][] => {
+  return Array.from(workspaces.entries()).map(([workspaceId, workspace]) => [
+    workspaceId,
+    {
+      ...workspace,
+      layout: {
+        ...workspace.layout,
+        tabs: Array.from(workspace.layout.tabs.entries()).map(
+          ([tabId, tab]): [string, PersistedTab] => [
+            tabId,
+            {
+              ...tab,
+              panels: Array.from(tab.panels.entries()),
+            },
+          ]
+        ),
+      },
+    },
+  ])
+}
+
 // Custom storage implementation to handle Map serialization
 const mapStorage = {
   getItem: (name: string) => {
     const str = localStorage.getItem(name)
     if (!str) return null
     try {
-      const parsed = JSON.parse(str) as { state: { workspaces: Map<string, Workspace> } }
-      const deserializedState = {
+      const parsed = JSON.parse(str) as PersistedWorkspaceState
+      return {
         ...parsed,
         state: {
           ...parsed.state,
-          workspaces: new Map(),
+          workspaces: deserializeWorkspaces(parsed.state.workspaces),
         },
       }
-
-      // Deserialize workspaces
-      if (parsed.state.workspaces) {
-        for (const [workspaceId, workspace] of parsed.state.workspaces) {
-          const deserializedWorkspace = {
-            ...workspace,
-            layout: {
-              ...workspace.layout,
-              tabs: new Map(),
-            },
-          }
-
-          // Deserialize tabs
-          if (workspace.layout.tabs) {
-            for (const [tabId, tab] of workspace.layout.tabs) {
-              deserializedWorkspace.layout.tabs.set(tabId, {
-                ...tab,
-                panels: new Map(tab.panels || []),
-              })
-            }
-          }
-
-          deserializedState.state.workspaces.set(workspaceId, deserializedWorkspace)
-        }
-      }
-
-      return deserializedState
     } catch {
       return null
     }
   },
   setItem: (name: string, value: unknown) => {
-    const serializedState = value as { state: { workspaces: Map<string, Workspace> } }
-    const newSerializedState: { state: { workspaces: Map<string, Workspace> } } = {
+    const serializedState = value as { state: WorkspaceState; version?: number }
+    const newSerializedState: PersistedWorkspaceState = {
       ...serializedState,
       state: {
         ...serializedState.state,
-        workspaces: new Map(
-          Array.from(serializedState.state.workspaces.entries()).map(([workspaceId, workspace]) => [
-            workspaceId,
-            {
-              ...workspace,
-              layout: {
-                ...workspace.layout,
-                tabs: new Map(
-                  Array.from(workspace.layout.tabs.entries()).map(([tabId, tab]) => [
-                    tabId,
-                    {
-                      ...tab,
-                      panels: new Map(
-                        Array.from(tab.panels.entries()).map(([panelId, panel]) => [
-                          panelId,
-                          {
-                            ...panel,
-                          },
-                        ])
-                      ),
-                    },
-                  ])
-                ),
-              },
-            },
-          ])
-        ),
+        workspaces: serializeWorkspaces(serializedState.state.workspaces),
       },
     }
 
@@ -199,16 +228,27 @@ const mapStorage = {
 // Enable Map/Set support for Immer
 enableMapSet()
 
-export const createWorkspaceStore = () =>
+export const createWorkspaceStore = (options: WorkspaceStoreOptions = {}) =>
   create<WorkspaceStore>()(
     persist(
       immer<WorkspaceStore>((set, get) => {
         const defaultWorkspace = createDefaultWorkspace()
+        const initialWorkspaces =
+          options.initialWorkspaces && options.initialWorkspaces.length > 0
+            ? options.initialWorkspaces
+            : [defaultWorkspace]
+        const initialWorkspaceMap = new Map(
+          initialWorkspaces.map(workspace => [workspace.uuid, workspace])
+        )
+        const initialActiveWorkspaceId =
+          options.activeWorkspaceId && initialWorkspaceMap.has(options.activeWorkspaceId)
+            ? options.activeWorkspaceId
+            : initialWorkspaces[0]?.uuid || ""
 
         return {
           // Initial state
-          workspaces: new Map([[defaultWorkspace.uuid, defaultWorkspace]]),
-          activeWorkspaceId: defaultWorkspace.uuid,
+          workspaces: initialWorkspaceMap,
+          activeWorkspaceId: initialActiveWorkspaceId,
 
           // Workspace management
           createWorkspace: (name: string) => {
@@ -402,7 +442,7 @@ export const createWorkspaceStore = () =>
         }
       }),
       {
-        name: "workspace-store",
+        name: options.storageName ?? "workspace-store",
         storage: mapStorage,
       }
     )


### PR DESCRIPTION
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.

## Summary

Fixes Sail workspace-store persistence and rehydration for the v3 beta branch.

This change preserves the in-memory `Map` shape used by the workspace store while making persisted storage round-trip correctly through JSON. It also supports seeded workspace state for demo/test environments without losing the Map-backed runtime API.

This came out of the TraderX state 014 FDC3 v3/Sail integration work, where the visible Sail layout could be serialized from memory but `localStorage.getItem("workspace-store")` only showed an empty object for `workspaces`.

## Related Tracking

- Implementers feedback issue: https://github.com/finos/FDC3-Sail/issues/313
- TraderX integration PR: https://github.com/finos/traderX/pull/432

## Validation

- `npm run test:run -w @finos/sail-web -- workspace-store`
