### PR TITLE
Support multiple App Directory sources

### DIFF
--- a/packages/sail-platform-api/src/sail-platform.ts
+++ b/packages/sail-platform-api/src/sail-platform.ts
@@ -87,6 +87,11 @@ export interface SailPlatformConfig {
   apps?: DirectoryApp[]
 
   /**
+   * App Directory endpoint URLs to load into the directory.
+   */
+  appDirectories?: string[]
+
+  /**
    * Custom user channels (defaults to standard FDC3 channels).
    */
   userChannels?: BrowserTypes.Channel[]
@@ -232,6 +237,7 @@ export class SailPlatform {
     const desktopAgent = createBrowserDesktopAgent({
       appLauncher: this.config.appLauncher,
       apps: this.config.apps,
+      appDirectories: this.config.appDirectories,
       userChannels: this.config.userChannels,
       implementationMetadata: this.config.implementationMetadata,
       openContextListenerTimeoutMs: this.config.openContextListenerTimeoutMs,

--- a/packages/sail-web/src/__tests__/config/app-directory-sources.test.ts
+++ b/packages/sail-web/src/__tests__/config/app-directory-sources.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test"
+import { parseAppDirectoryUrls } from "../../config/app-directory-sources"
+
+describe("app directory source config", () => {
+  it("parses comma and newline separated URLs", () => {
+    expect(
+      parseAppDirectoryUrls(
+        "https://a.example/v2/apps, https://b.example/v2/apps\nhttps://c.example/v2/apps"
+      )
+    ).toEqual([
+      "https://a.example/v2/apps",
+      "https://b.example/v2/apps",
+      "https://c.example/v2/apps",
+    ])
+  })
+
+  it("deduplicates configured URLs", () => {
+    expect(
+      parseAppDirectoryUrls([
+        "https://a.example/v2/apps",
+        "https://a.example/v2/apps",
+        " https://b.example/v2/apps ",
+      ])
+    ).toEqual(["https://a.example/v2/apps", "https://b.example/v2/apps"])
+  })
+
+  it("ignores unsupported values", () => {
+    expect(parseAppDirectoryUrls(undefined)).toEqual([])
+    expect(parseAppDirectoryUrls({ value: "https://example.com/v2/apps" })).toEqual([])
+  })
+})

--- a/packages/sail-web/src/__tests__/stores/app-directory-store.test.ts
+++ b/packages/sail-web/src/__tests__/stores/app-directory-store.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vite-plus/test"
+import type { SailPlatform } from "@finos/sail-platform-api"
+import { createAppDirectoryStore } from "../../stores/app-directory-store"
+
+const createPlatform = (directoryUrls: string[] = []) =>
+  ({
+    agent: {
+      getState: vi.fn(() => ({
+        appDirectory: {
+          directoryUrls,
+          apps: [
+            {
+              appId: "traderx-web",
+              name: "TraderX",
+              title: "TraderX",
+              type: "web",
+              details: {
+                url: "http://localhost:8080/trade",
+              },
+            },
+          ],
+        },
+      })),
+    },
+  }) as unknown as SailPlatform
+
+describe("app-directory-store", () => {
+  it("loads apps and mirrors directory URLs from the agent state", () => {
+    const platform = createPlatform(["http://localhost:8080/fdc3/appd/v2/apps"])
+    const store = createAppDirectoryStore(platform)
+
+    store.getState().loadApps()
+
+    expect(store.getState().apps.map(app => app.appId)).toEqual(["traderx-web"])
+    expect(store.getState().directoryUrls).toEqual(["http://localhost:8080/fdc3/appd/v2/apps"])
+  })
+})

--- a/packages/sail-web/src/components/app-directory/AppDirectory.tsx
+++ b/packages/sail-web/src/components/app-directory/AppDirectory.tsx
@@ -109,7 +109,9 @@ interface AppDirectoryProps {
 }
 
 export function AppDirectory({ panelProps }: AppDirectoryProps) {
-  const { apps, isLoading, error, loadApps, refreshApps } = useAppDirectoryStore()
+  const { apps, isLoading, error, directoryUrls, loadApps, refreshApps, loadDirectoriesFromUrls } =
+    useAppDirectoryStore()
+  const [directoryUrl, setDirectoryUrl] = useState("")
   const { addPanel, workspaces, activeWorkspaceId } = useWorkspaceStore()
   const { closeQuickAccessPanel } = useUIStore()
   const activeWorkspace = workspaces.get(activeWorkspaceId)
@@ -183,6 +185,20 @@ export function AppDirectory({ panelProps }: AppDirectoryProps) {
     closeQuickAccessPanel()
   }
 
+  const handleAddDirectory = () => {
+    const nextUrl = directoryUrl.trim()
+    if (!nextUrl || directoryUrls.includes(nextUrl)) {
+      return
+    }
+
+    setDirectoryUrl("")
+    void loadDirectoriesFromUrls([...directoryUrls, nextUrl])
+  }
+
+  const handleRemoveDirectory = (url: string) => {
+    void loadDirectoriesFromUrls(directoryUrls.filter(entry => entry !== url))
+  }
+
   if (error) {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
@@ -239,6 +255,70 @@ export function AppDirectory({ panelProps }: AppDirectoryProps) {
           Browse and launch applications ({apps.length} available)
         </p>
       </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-base">App Directory Sources</CardTitle>
+          <CardDescription>
+            Add or reload App Directory endpoints for this Sail session.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={directoryUrl}
+                onChange={event => setDirectoryUrl(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === "Enter") {
+                    handleAddDirectory()
+                  }
+                }}
+                placeholder="https://example.com/v2/apps"
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex-1 rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleAddDirectory}
+                className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm"
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                onClick={() => void loadDirectoriesFromUrls(directoryUrls)}
+                className="bg-secondary text-secondary-foreground hover:bg-secondary/80 rounded-md px-4 py-2 text-sm"
+              >
+                Reload
+              </button>
+            </div>
+            {directoryUrls.length > 0 ? (
+              <div className="flex flex-col gap-2">
+                {directoryUrls.map(url => (
+                  <div
+                    key={url}
+                    className="border-border flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-sm"
+                  >
+                    <span className="truncate">{url}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveDirectory(url)}
+                      className="text-muted-foreground hover:text-foreground text-xs"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                No external App Directory sources configured.
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {apps.map(app => (

--- a/packages/sail-web/src/config/app-directory-sources.ts
+++ b/packages/sail-web/src/config/app-directory-sources.ts
@@ -1,0 +1,25 @@
+declare global {
+  interface Window {
+    __SAIL_APP_DIRECTORY_URLS__?: string | string[]
+  }
+}
+
+export function parseAppDirectoryUrls(value: unknown): string[] {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(/[,\n]/)
+      : []
+  const urls = rawValues.map(entry => String(entry).trim()).filter(entry => entry.length > 0)
+
+  return Array.from(new Set(urls))
+}
+
+export function getConfiguredAppDirectoryUrls(): string[] {
+  return Array.from(
+    new Set([
+      ...parseAppDirectoryUrls(import.meta.env.VITE_SAIL_APP_DIRECTORY_URLS),
+      ...parseAppDirectoryUrls(window.__SAIL_APP_DIRECTORY_URLS__),
+    ])
+  )
+}

--- a/packages/sail-web/src/main.tsx
+++ b/packages/sail-web/src/main.tsx
@@ -8,6 +8,7 @@ import defaultAppDirectory from "../fixtures/default-app-directory.json"
 
 import "./index.css"
 import App from "./App"
+import { getConfiguredAppDirectoryUrls } from "./config/app-directory-sources"
 import { useWorkspaceStore } from "./stores/workspace-store"
 import { ChannelSelectorTestPage } from "./tests/ChannelSelectorTestPage"
 
@@ -88,6 +89,7 @@ if (isChannelSelectorE2e) {
   const platform = new SailPlatform({
     debug: true,
     appLauncher,
+    appDirectories: getConfiguredAppDirectoryUrls(),
     apps: [
       ...defaultAppDirectory.applications,
       ...conformanceAppDirectory.applications,

--- a/packages/sail-web/src/stores/app-directory-store.ts
+++ b/packages/sail-web/src/stores/app-directory-store.ts
@@ -117,14 +117,16 @@ export const createAppDirectoryStore = (platform: SailPlatform) =>
 
       // Load apps from the browser desktop agent's app directory
       loadApps: () => {
-        const { setLoading, setError, setApps } = get()
+        const { setLoading, setError, setApps, setDirectoryUrls } = get()
 
         try {
           setLoading(true)
           setError(null)
 
-          const apps = retrieveAllApps(platform.agent.getState().appDirectory)
+          const appDirectory = platform.agent.getState().appDirectory
+          const apps = retrieveAllApps(appDirectory)
 
+          setDirectoryUrls(appDirectory.directoryUrls)
           setApps(apps)
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : "Failed to load apps"


### PR DESCRIPTION
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.

## Summary

Adds support for multiple App Directory sources in Sail v3 beta.

The web app can now load App Directory entries from more than one configured source, and the App Directory UI exposes source management so demo/runtime environments can add or manage additional directories without patching the bundled fixture.

This supports the TraderX state 014 demo model where TraderX supplies TraderX, Mini TraderX, and TraderX Intent Launcher from its own AppD endpoint, while Sail can also keep its native/demo marketplace entries.

## Related Tracking

- Implementers feedback issue: https://github.com/finos/FDC3-Sail/issues/313
- TraderX integration PR: https://github.com/finos/traderX/pull/432

## Validation

- `npm run test:run -w @finos/sail-web -- app-directory`
- `npm run build -w @finos/sail-platform-api`
- `npm run typecheck -w @finos/sail-web`
