### PR TITLE
fix: update uuid to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13934,11 +13934,24 @@
         "@finos/fdc3": "2.2.1-beta.3",
         "socket.io-client": "^4.7.5",
         "typescript": "^5.7.3",
-        "uuid": "^11.0.5"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "fast-check": "^4.5.3",
         "rimraf": "^6.0.1"
+      }
+    },
+    "packages/common/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/da-impl": {
@@ -13948,7 +13961,7 @@
       "dependencies": {
         "@finos/fdc3": "2.2.1-beta.3",
         "@types/uuid": "^10.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@cucumber/cucumber": "10.3.1",
@@ -13978,7 +13991,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.17.0",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.1"
       }
     },
     "packages/da-impl/node_modules/@types/node": {
@@ -14014,7 +14027,9 @@
       "license": "MIT"
     },
     "packages/da-impl/node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -14022,7 +14037,7 @@
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/web": {
@@ -14049,7 +14064,7 @@
         "socket.io-client": "^4.7.5",
         "tsx": "^4.5.0",
         "typescript": "^5.3.2",
-        "uuid": "^9.0.1",
+        "uuid": "^11.1.1",
         "vite-express": "^0.22.1",
         "ws": "^8.18.0"
       },
@@ -14172,14 +14187,16 @@
       "license": "MIT"
     },
     "packages/web/node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "packages/web/node_modules/ws": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,6 @@
     "@finos/fdc3": "2.2.1-beta.3",
     "socket.io-client": "^4.7.5",
     "typescript": "^5.7.3",
-    "uuid": "^11.0.5"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/da-impl/package.json
+++ b/packages/da-impl/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@finos/fdc3": "2.2.1-beta.3",
     "@types/uuid": "^10.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@cucumber/cucumber": "10.3.1",
@@ -56,6 +56,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.17.0",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.1"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,7 +50,7 @@
     "socket.io-client": "^4.7.5",
     "tsx": "^4.5.0",
     "typescript": "^5.3.2",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.1",
     "vite-express": "^0.22.1",
     "ws": "^8.18.0"
   }


### PR DESCRIPTION
## Summary

Closes #285.
Closes #287.

Updates the direct `uuid` dependencies used by the common, desktop-agent implementation, and web workspaces to `11.1.1`, the patched v11 release identified by [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq). The lockfile is updated for the same workspace-local dependency paths.

## Why

The reported versions include `11.1.0` and `9.0.1`, both of which fall below the advisory's first patched v11 release. Keeping the workspaces on one patched version removes those direct vulnerable dependency paths while avoiding a broader unrelated dependency upgrade.

## Test Plan

- [x] `npm ci --ignore-scripts`
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run build`
- [x] runtime `v4()` smoke test against each updated workspace dependency (`common`, `da-impl`, and `web`)
- [x] `npm ls uuid --all` confirms all three direct workspace copies resolve to `11.1.1`
- [x] `git diff --check`

`npm run test` currently stops during TypeScript compilation because `packages/da-impl/test/step-definitions/app-channel.steps.ts` imports the undeclared `@finos/fdc3-testing` package. The same import/package-manifest mismatch is present on `main` and is unrelated to this dependency-only change.
