### PR TITLE
Persist user workspaces

### DIFF
--- a/packages/sail-finance/src/components/layout-grid/Layout.tsx
+++ b/packages/sail-finance/src/components/layout-grid/Layout.tsx
@@ -26,7 +26,7 @@ export type { Panel as WorkspacePanel } from "../../stores/workspace-store"
 const Layout = (props: DockviewSailProps) => {
   const api = useRef<DockviewApi | undefined>(undefined)
   const [mountedPanels, setMountedPanels] = useState<Map<string, FDC3AppPanel>>(new Map())
-  const restoredWorkspaceIdRef = useRef<string | null>(null)
+  const [restoredWorkspaceId, setRestoredWorkspaceId] = useState<string | null>(null)
   const [apiReady, setApiReady] = useState(false)
   const isRestoringRef = useRef(false)
 
@@ -55,11 +55,16 @@ const Layout = (props: DockviewSailProps) => {
   const onReady = (event: DockviewReadyEvent) => {
     api.current = event.api
     setApiReady(true)
+    // A fresh Dockview instance holds no panels, so the saved layout must be replayed into
+    // it and panel tracking must start over.
+    setRestoredWorkspaceId(null)
+    // Same reference when already empty so React can bail out of the re-render.
+    setMountedPanels(prev => (prev.size === 0 ? prev : new Map<string, FDC3AppPanel>()))
   }
 
   // Reset restoration tracking when workspace changes
   useEffect(() => {
-    restoredWorkspaceIdRef.current = null
+    setRestoredWorkspaceId(null)
   }, [activeWorkspaceId])
 
   // Layout restoration - only run once per workspace when API is ready
@@ -69,7 +74,7 @@ const Layout = (props: DockviewSailProps) => {
     }
 
     // Only restore once per workspace ID
-    if (restoredWorkspaceIdRef.current === activeWorkspaceId) {
+    if (restoredWorkspaceId === activeWorkspaceId) {
       return
     }
 
@@ -85,7 +90,7 @@ const Layout = (props: DockviewSailProps) => {
       Object.keys(savedLayoutState).length === 0
     ) {
       // No valid layout to restore, mark as restored to prevent re-checking
-      restoredWorkspaceIdRef.current = activeWorkspaceId
+      setRestoredWorkspaceId(activeWorkspaceId)
       return
     }
 
@@ -93,7 +98,7 @@ const Layout = (props: DockviewSailProps) => {
       console.log("Restoring layout state from workspace store")
       // Prevent saveState from running during restoration
       isRestoringRef.current = true
-      restoredWorkspaceIdRef.current = activeWorkspaceId
+      setRestoredWorkspaceId(activeWorkspaceId)
 
       // The layout state comes from Dockview's toJSON() which returns SerializedDockview
       // We store it as any in the store, so we need to cast it back
@@ -115,9 +120,9 @@ const Layout = (props: DockviewSailProps) => {
       console.warn("Failed to restore layout state:", error)
       isRestoringRef.current = false
       setDockviewLayout(activeWorkspaceId, null)
-      restoredWorkspaceIdRef.current = activeWorkspaceId
+      setRestoredWorkspaceId(activeWorkspaceId)
     }
-  }, [apiReady, activeWorkspaceId, getDockviewLayout, setDockviewLayout])
+  }, [apiReady, activeWorkspaceId, restoredWorkspaceId, getDockviewLayout, setDockviewLayout])
 
   // Event listeners and state saving - separate from restoration
   useEffect(() => {
@@ -226,6 +231,10 @@ const Layout = (props: DockviewSailProps) => {
     // oxlint-disable-next-line typescript/no-unnecessary-condition -- localStorage-persisted state; panels derives from JSON-parsed workspace data
     if (!api.current || !panels || !activeTabId || !activeWorkspaceId) return
 
+    // Wait for the saved layout to be replayed. Adding panels first puts them in one default
+    // group and the resulting onDidAddPanel -> saveState overwrites the layout being restored.
+    if (restoredWorkspaceId !== activeWorkspaceId) return
+
     const currentPanelIds = Array.from(mountedPanels.keys())
     const externalPanelIds = panels.map(p => p.panelId)
 
@@ -298,7 +307,7 @@ const Layout = (props: DockviewSailProps) => {
           setMountedPanels(prev => new Map(prev).set(panel.panelId, fdc3Panel))
         }
       })
-  }, [panels, activeTabId, mountedPanels, activeWorkspaceId])
+  }, [panels, activeTabId, mountedPanels, activeWorkspaceId, restoredWorkspaceId])
 
   return (
     <div

--- a/packages/sail-finance/src/stores/workspace-store.ts
+++ b/packages/sail-finance/src/stores/workspace-store.ts
@@ -157,42 +157,12 @@ const mapStorage = {
     }
   },
   setItem: (name: string, value: unknown) => {
-    const serializedState = value as { state: { workspaces: Map<string, Workspace> } }
-    const newSerializedState: { state: { workspaces: Map<string, Workspace> } } = {
-      ...serializedState,
-      state: {
-        ...serializedState.state,
-        workspaces: new Map(
-          Array.from(serializedState.state.workspaces.entries()).map(([workspaceId, workspace]) => [
-            workspaceId,
-            {
-              ...workspace,
-              layout: {
-                ...workspace.layout,
-                tabs: new Map(
-                  Array.from(workspace.layout.tabs.entries()).map(([tabId, tab]) => [
-                    tabId,
-                    {
-                      ...tab,
-                      panels: new Map(
-                        Array.from(tab.panels.entries()).map(([panelId, panel]) => [
-                          panelId,
-                          {
-                            ...panel,
-                          },
-                        ]),
-                      ),
-                    },
-                  ]),
-                ),
-              },
-            },
-          ]),
-        ),
-      },
-    }
-
-    localStorage.setItem(name, JSON.stringify(newSerializedState))
+    // `JSON.stringify` turns a Map into `{}`, which would drop every workspace, tab and
+    // panel. Write Maps as entry arrays instead — getItem rebuilds the Maps on the way back.
+    localStorage.setItem(
+      name,
+      JSON.stringify(value, (_key, val: unknown) => (val instanceof Map ? Array.from(val) : val)),
+    )
   },
   removeItem: (name: string) => {
     localStorage.removeItem(name)


### PR DESCRIPTION
## Summary

Fixes two bugs that stopped a user's workspace from surviving a page reload in `@finos/sail-finance`. Workspaces, tabs and panels were written to `localStorage` as `{}`, and the Dockview layout that did survive was overwritten while it was being restored.

### `workspace-store` — Maps were serialised as `{}`

`mapStorage.setItem` rebuilt the nested `workspaces` → `tabs` → `panels` structure by spreading each level, but the result was still a tree of `Map`s by the time it reached `JSON.stringify`, which serialises a `Map` as `{}`. Every workspace, tab and panel was therefore dropped on write, and `getItem` — which expects entry arrays it can iterate — had nothing to read back.

Replaced the manual rebuild with a `JSON.stringify` replacer that converts any `Map` to its entry array. That is the shape `getItem` already reads, and it removes ~30 lines of spreading that had no effect on the output.

### `Layout` — panel mounting raced the layout restore

`restoredWorkspaceId` was held in a `useRef`, so updating it never triggered a re-render and the panel-mounting effect had no way to observe whether restoration had finished. Panels were mounted before the saved Dockview layout was replayed, which put them all in a single default group, and the resulting `onDidAddPanel` → `saveState` wrote that flat layout back over the one being restored.

- Moved the flag to `useState` so both effects can react to it.
- The panel-mounting effect now bails out until `restoredWorkspaceId === activeWorkspaceId`.
- `onReady` resets the flag and clears `mountedPanels` — a fresh Dockview instance holds no panels, so tracking has to start over. The existing `Map` is kept by reference when already empty so React can skip the re-render.

## Why

With either bug present the workspace is effectively not persisted: reloading Sail Finance loses the apps the user had open, and anything that does come back is flattened into one group.

## Test Plan

Automated:

- `npm run typecheck`
- `npm run lint`
- `npm test`

Manual, against `npm run dev`:

1. Open several apps in a workspace and arrange them across more than one Dockview group.
2. Reload the page — the same panels should return in the same arrangement.
3. Inspect the `workspace-store` key in `localStorage`: `state.workspaces` should be an array of `[id, workspace]` entries rather than `{}`.
4. Create a second workspace, switch between the two, and reload — each should restore its own layout.

## Notes for reviewers

There is no unit test for `mapStorage` yet; sibling stores have coverage under `packages/sail-finance/src/__tests__/stores/`. Happy to add a round-trip test for the serialiser if you'd like it in this PR.
