### PR TITLE
fix: align security policy with FINOS responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,16 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.0.1   | :white_check_mark: |
+FDC3 Sail adheres to the [FINOS Security Vulnerabilities Responsible Disclosure Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure).
+If you believe you have found a security vulnerability in FDC3 Sail, please report it
+privately using one of the methods below — **do not** open a public GitHub Issue.
 
 ## Reporting a Vulnerability
 
-### How to report a vulnerability:
+- **GitHub private vulnerability reporting (preferred):** use the ["Report a vulnerability"](https://github.com/finos/FDC3-Sail/security/advisories/new) button under this repository's **Security** tab.
+- **Email:** the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md), cc [security@finos.org](mailto:security@finos.org).
 
-- Click on **New Issue** (https://github.com/finos/fdc3-sail/issues/new/choose) and select **Bug Report**
+We will acknowledge your report within 5 working days, give a triage outcome within 14 days,
+and update you at least every 30 days while a confirmed issue is open. Fixes are released and
+disclosed in accordance with the FINOS policy above.
 
-### How soon will I receive an initial response a reported vulnerability:
-
-- Within 14 days
-
-### How often you can expect to get an update on a reported vulnerability:
-
-- Within 6 months
+Vulnerabilities in the FDC3 standard itself should be reported to [finos/FDC3](https://github.com/finos/FDC3/security/policy).


### PR DESCRIPTION
## What

Rewrites `SECURITY.md`, which dated from September 2022 and instructed reporters to **open a public GitHub Issue**.

That directly contradicts the [FINOS Security Vulnerabilities Responsible Disclosure Policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure):

> a GitHub Issue **must NOT** be created to track the issue since that will make the issue public

## Changes

| Was | Now |
|---|---|
| "Click on **New Issue** … select Bug Report" | Private reporting only — GitHub PVR preferred, maintainer email cc `security@finos.org` as fallback |
| No reference to the FINOS policy | Cites it, and states plainly not to open a public issue |
| `0.0.1` as the only supported version (a 2022 test pre-release) | Table removed — see note below |
| "initial response within 14 days", "updates within 6 months" | 5 working days to acknowledge, 14 days to triage, 30-day progress updates |
| — | FDC3 *standard* vulnerabilities routed to [finos/FDC3](https://github.com/finos/FDC3/security/policy) |

Follows the [finos/git-proxy](https://github.com/finos/git-proxy/blob/main/SECURITY.md) pattern, trimmed to what is actually required. Net **16 lines**.

**On dropping the supported-versions table:** it is not required by the OSPS Baseline (no control in any of the 8 baseline files references supported versions or EOL). Sail has no written support policy, and v3 would invalidate any table written today. Support status belongs in release documentation. Happy to reinstate it if maintainers would rather keep the section.

## Why now

The OSPS Baseline scanner currently fails the project on `OSPS-VM-03.01`:

> No private vulnerability reporting contact in Security Insights data **and** GitHub private vulnerability reporting is disabled

This PR addresses the documentation half. See the ask below for the other half.

Also relevant: the weekly `OSPS Security Assessment` workflow has been reporting green while producing no results — every run since at least 27 July fails with `401 Unauthorized` because `secrets.PVTR_GITHUB_TOKEN` does not exist at repo or org level. I'll raise that separately.

---

## 🙏 Admin action needed — @TheJuanAndOnly99

Would you mind enabling **private vulnerability reporting** on this repo? It needs `admin`, and I only have `maintain`, so I can't do it myself.

**Settings → Advanced Security → Private vulnerability reporting → Enable**

Or, equivalently:

```bash
gh api -X PUT repos/finos/FDC3-Sail/private-vulnerability-reporting
```

It would be great to have this land alongside the merge, because this PR points reporters at `.../security/advisories/new` — and until PVR is on, that link does nothing for an external reporter. Right now there is no private route to report a vulnerability in Sail at all.

No rush if it needs to go through a process — just let me know and I'll hold the merge. Thank you!

---

- [x] `npx prettier --check SECURITY.md` passes
- [x] All external links verified (HTTP 200)
- [x] Commit is DCO signed off
