### PR TITLE
fix(ci): repair the CVE and Semgrep scanners, add OSV malicious-package detection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    labels: ["dependencies"]
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types: ["minor", "patch"]
+      prod-patches:
+        dependency-type: production
+        update-types: ["patch"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies", "github-actions"]
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
       - name: Prettier
         run: npm run format:check

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      security-events: write
     strategy:
       matrix:
         node-version: [24.x]
@@ -40,8 +41,57 @@ jobs:
 
       - name: NPM security audit
         run: npm audit --audit-level=high
-      # OSS Index requires a free account + token since auth enforcement (Sonatype).
-      # Repo secrets: OSS_INDEX_USERNAME, OSS_INDEX_TOKEN — https://ossindex.sonatype.org/
-      - name: Sonatype OSS Index audit
-        if: ${{ secrets.OSS_INDEX_USERNAME != '' && secrets.OSS_INDEX_TOKEN != '' }}
-        run: npx --yes auditjs ossi -u "${{ secrets.OSS_INDEX_USERNAME }}" -p "${{ secrets.OSS_INDEX_TOKEN }}"
+
+      # The anonymous Sonatype OSS Index API now returns 401 without a registered
+      # account, and OSV-Scanner below already covers what that account would add,
+      # so the old Sonatype step has been replaced with OSV-Scanner.
+      # if: always() matters — `npm audit` above is a gate that currently exits 1,
+      # and without this OSV would be skipped and never write its SARIF.
+      - name: OSV-Scanner
+        id: osv
+        if: always()
+        continue-on-error: true
+        uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
+        with:
+          scan-args: |-
+            --lockfile=package-lock.json
+            --format=sarif
+            --output=osv.sarif
+
+      # failure() alone is unsafe: any earlier step failure still triggers
+      # upload-sarif, but osv.sarif was never written.
+      - name: Check SARIF output
+        id: sarif
+        if: always()
+        run: |
+          f="osv.sarif"
+          if [ -f "$f" ] && [ -s "$f" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        if: always() && steps.sarif.outputs.ok == 'true'
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 #v4.35.2
+        with:
+          sarif_file: osv.sarif
+
+      # Hard fail on the OpenSSF Malicious Packages feed (OSV advisory ids
+      # starting with MAL-). This is the capability OSV adds over plain audits.
+      - name: Fail on malicious packages (OSV MAL- advisories)
+        if: always() && steps.sarif.outputs.ok == 'true'
+        run: |
+          mal_ids=$(jq -r '
+            [ .runs[]
+              | (.results[]?.ruleId // empty),
+                (.tool.driver.rules[]?.id // empty),
+                (.tool.driver.rules[]?.fullDescription.text // empty)
+            ]
+            | map(scan("MAL-[0-9]{4}-[0-9]+")) | flatten | unique | .[]' osv.sarif)
+          if [ -n "$mal_ids" ]; then
+            echo "Malicious packages detected:"
+            echo "$mal_ids"
+            exit 1
+          fi
+          echo "No malicious packages detected."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,10 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # SCORECARD_TOKEN should be a fine-grained PAT with read access to
+          # administration; without it, Branch-Protection cannot be evaluated
+          # because the default GITHUB_TOKEN can't read classic branch protection.
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
 
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,5 @@
-# SEMGREP_APP_TOKEN: Semgrep AppSec Platform > Settings (or help@finos.org for FINOS repos).
+# SEMGREP_APP_TOKEN is OPTIONAL: Semgrep AppSec Platform > Settings (or help@finos.org for
+# FINOS repos). When set, it adds Semgrep's platform rules on top of the local p/* packs below.
 # SARIF upload needs repo Settings → Actions → Workflow permissions to allow security events.
 name: Semgrep
 
@@ -34,9 +35,11 @@ jobs:
       - name: Install Semgrep
         run: pip install semgrep
       - name: Semgrep CI
+        continue-on-error: true
         run: |
           mkdir -p reports
-          semgrep ci --sarif --sarif-output=reports/semgrep.sarif
+          semgrep ci --config p/typescript --config p/javascript --config p/react \
+            --sarif --sarif-output=reports/semgrep.sarif
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules
+.env
+.env.*
+!.env.example
 .DS_Store
 dist
 *.local


### PR DESCRIPTION
## Why

Three of this repo's scanners are not doing what their status badges suggest.

| Workflow | State | Evidence |
|---|---|---|
| `cve-scanning.yml` | **Failing on every run** | 118 consecutive failures since 25 Mar 2026 (commit `1dd07a2d`, "Gh actions fix" #231) |
| `semgrep.yml` | **Green, produces nothing** | `semgrep ci` with an unset `SEMGREP_APP_TOKEN` prints a login warning, exits 0, writes no SARIF |
| `scorecard.yml` | **Runs, but can't score branch protection** | `Branch-Protection: -1 — "some github tokens can't read classic branch protection rules"` |

Code scanning currently holds analyses from **CodeQL and Scorecard only** — nothing has ever been uploaded by Semgrep.

### The `cve-scanning.yml` failure

```
cve-scanning.yml:46:17: context "secrets" is not allowed here.
  available contexts are "env", "github", "inputs", "job", "matrix",
  "needs", "runner", "steps", "strategy", "vars"
```

`secrets` is not a valid context in a step-level `if:`. An invalid expression makes the **entire workflow file** unparseable, so it is rejected at parse time — every run fails before any step executes. Confirmed with `actionlint` against the historical file: `7e9a1dab` lints clean, `1dd07a2d` does not.

## What this changes

**`cve-scanning.yml`** — removes the Sonatype OSS Index step (the source of the invalid `if:`) and replaces it with OSV-Scanner.

Sonatype was not worth repairing: the anonymous OSS Index API now returns `401`, so the step needs a registered account to contribute anything OSV does not already cover.

OSV adds one thing nothing else here has — **malicious-package detection**. OSV.dev carries the OpenSSF Malicious Packages feed (`MAL-` advisory IDs), which is what OSPS Baseline `VM-05.03` asks for ("changes are evaluated against a policy for malicious *and* vulnerable dependencies"). Findings upload to code scanning as SARIF; only `MAL-` advisories hard-fail the job, so the existing `npm audit` gate keeps its current meaning.

Two details worth reviewing:
- The OSV step is `if: always()` because `npm audit --audit-level=high` currently exits 1. Without it, OSV would be skipped and never write its SARIF.
- The `MAL-` check scans rule IDs *and* rule descriptions, because OSV picks a single representative ID per alias group — a malicious-package entry can surface under a `GHSA-` ID.

**`semgrep.yml`** — passes explicit `--config p/typescript --config p/javascript --config p/react`. `semgrep ci` refuses to run without a login *unless* it is given a config, so this makes it work today with no token. `SEMGREP_APP_TOKEN` stays wired up and becomes purely additive if FINOS provisions one.

Semgrep is not redundant with CodeQL here — measured on this tree, Semgrep flags `wildcard-postmessage-configuration` at two call sites CodeQL does not, and CodeQL flags `js/cross-window-information-leak` in `embed.ts` that Semgrep does not.

**`ci.yml`** — `npm i` → `npm ci`.

`npm i` mutates the tree away from the lockfile, and it has already drifted: the lockfile pins `@finos/fdc3@2.2.1-beta.3` while the installed tree carries `2.2.3`. Every scanner reads the lockfile while CI builds something else. It also breaks `npm sbom`, which currently exits with `ESBOMPROBLEMS`.

**`scorecard.yml`** — adds `repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}`.

`main` *is* protected, but the default `GITHUB_TOKEN` cannot read classic branch protection, so Scorecard scores the check `-1` and the project gets no credit for it. The `||` fallback means behaviour is unchanged until an admin creates the secret (a fine-grained PAT with read access to administration).

**`.github/dependabot.yml`** — new. The repo currently receives only unscheduled security-alert PRs. This adds weekly grouped updates for npm and `github-actions`, grouped so dev-dependency minor/patch bumps and production patches each land as one PR.

**`.gitignore`** — adds `.env`, `.env.*`, `!.env.example`. There was no env-file coverage at all.

## Verification

- `actionlint` clean across all 7 workflows
- `grep -rn 'if:.*secrets\.' .github/workflows/` returns nothing — the invalid-context bug is not reintroduced
- Every workflow and `dependabot.yml` parses as YAML
- `npm ci` succeeds from a clean `node_modules`; `npm run build` passes
- The `MAL-` filter was tested against a real 47-result OSV SARIF generated from this lockfile: silent on the real output, fires on an injected `MAL-` ID

`npm run test` fails in `packages/da-impl` with `TS2307: Cannot find module '@finos/fdc3-testing'`. That is **pre-existing and unrelated** — the package appears in neither `package.json` nor `package-lock.json`. #344 covers it.

## Not in this PR

- `SECURITY.md` — #342
- `OSPS.yml` — #343 (it fails the same way Semgrep does: `401 Bad credentials`, exit 0, 18 green runs, no SARIF)
- Clearing the existing high/critical audit findings — #346

## Needs a repo admin

None of these can be done from a PR:

1. Create the `SCORECARD_TOKEN` secret so `Branch-Protection` can be scored
2. Enable secret scanning **push protection**
3. Enable **non-provider secret patterns** — a Polygon.io API key sat in this repo's history undetected because Polygon is not a GitHub partner pattern
4. Enable **private vulnerability reporting**, which #342 assumes exists
